### PR TITLE
Extract version managers from ruby-lsp

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -36,6 +36,11 @@ export default tseslint.config(
   },
   {
     rules: {
+      "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
+      "@typescript-eslint/no-unsafe-return": "off",
       "@typescript-eslint/no-unused-vars": [
         "error",
         {

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,0 +1,15 @@
+import { exec } from "child_process";
+import { promisify } from "util";
+import { window } from "vscode";
+
+export interface RubyInterface {
+  error: boolean;
+  versionManager: { identifier: string };
+  rubyVersion?: string;
+}
+
+export const asyncExec = promisify(exec);
+export const RUBY_ENVIRONMENTS = "Ruby Environments";
+export const LOG_CHANNEL = window.createOutputChannel(RUBY_ENVIRONMENTS, {
+  log: true,
+});

--- a/src/ruby/asdf.ts
+++ b/src/ruby/asdf.ts
@@ -1,0 +1,88 @@
+import os from "os";
+import path from "path";
+
+import * as vscode from "vscode";
+
+import { VersionManager, ActivationResult } from "./versionManager";
+
+// A tool to manage multiple runtime versions with a single CLI tool
+//
+// Learn more: https://github.com/asdf-vm/asdf
+export class Asdf extends VersionManager {
+  async activate(): Promise<ActivationResult> {
+    // These directories are where we can find the ASDF executable for v0.16 and above
+    const possibleExecutablePaths = [
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "bin"),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "local", "bin"),
+    ];
+
+    // Prefer the path configured by the user, then the ASDF scripts for versions below v0.16 and finally the
+    // executables for v0.16 and above
+    const asdfPath =
+      (await this.getConfiguredAsdfPath()) ??
+      (await this.findAsdfInstallation()) ??
+      (await this.findExec(possibleExecutablePaths, "asdf"));
+
+    // If there's no extension name, then we are using the ASDF executable directly. If there is an extension, then it's
+    // a shell script and we have to source it first
+    const baseCommand = path.extname(asdfPath) === "" ? asdfPath : `. ${asdfPath} && asdf`;
+
+    const parsedResult = await this.runEnvActivationScript(`${baseCommand} exec ruby`);
+
+    return {
+      env: { ...process.env, ...parsedResult.env },
+      yjit: parsedResult.yjit,
+      version: parsedResult.version,
+      gemPath: parsedResult.gemPath,
+    };
+  }
+
+  // Only public for testing. Finds the ASDF installation URI based on what's advertised in the ASDF documentation
+  async findAsdfInstallation(): Promise<string | undefined> {
+    const scriptName = path.basename(vscode.env.shell) === "fish" ? "asdf.fish" : "asdf.sh";
+
+    // Possible ASDF installation paths as described in https://asdf-vm.com/guide/getting-started.html#_3-install-asdf.
+    // In order, the methods of installation are:
+    // 1. Git
+    // 2. Pacman
+    // 3. Homebrew M series
+    // 4. Homebrew Intel series
+    const possiblePaths = [
+      vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".asdf", scriptName),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "asdf-vm", scriptName),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "opt", "asdf", "libexec", scriptName),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "local", "opt", "asdf", "libexec", scriptName),
+    ];
+
+    for (const possiblePath of possiblePaths) {
+      try {
+        await vscode.workspace.fs.stat(possiblePath);
+        return possiblePath.fsPath;
+      } catch (_error: any) {
+        // Continue looking
+      }
+    }
+
+    this.outputChannel.info(`Could not find installation for ASDF < v0.16. Searched in ${possiblePaths.join(", ")}`);
+    return undefined;
+  }
+
+  private async getConfiguredAsdfPath(): Promise<string | undefined> {
+    const config = vscode.workspace.getConfiguration("rubyLsp");
+    const asdfPath = config.get<string | undefined>("rubyVersionManager.asdfExecutablePath");
+
+    if (!asdfPath) {
+      return;
+    }
+
+    const configuredPath = vscode.Uri.file(asdfPath);
+
+    try {
+      await vscode.workspace.fs.stat(configuredPath);
+      this.outputChannel.info(`Using configured ASDF executable path: ${asdfPath}`);
+      return configuredPath.fsPath;
+    } catch (_error: any) {
+      throw new Error(`ASDF executable configured as ${configuredPath.fsPath}, but that file doesn't exist`);
+    }
+  }
+}

--- a/src/ruby/chruby.ts
+++ b/src/ruby/chruby.ts
@@ -1,0 +1,440 @@
+import os from "os";
+import path from "path";
+
+import * as vscode from "vscode";
+
+import { WorkspaceChannel } from "../workspaceChannel";
+
+import { ActivationResult, VersionManager, ACTIVATION_SEPARATOR } from "./versionManager";
+
+interface RubyVersion {
+  engine?: string;
+  version: string;
+}
+
+class RubyActivationCancellationError extends Error {}
+
+// A tool to change the current Ruby version
+// Learn more: https://github.com/postmodern/chruby
+export class Chruby extends VersionManager {
+  // Only public so that we can point to a different directory in tests
+  public rubyInstallationUris = [
+    vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".rubies"),
+    vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "rubies"),
+  ];
+
+  constructor(
+    workspaceFolder: vscode.WorkspaceFolder,
+    outputChannel: WorkspaceChannel,
+    context: vscode.ExtensionContext,
+    manuallySelectRuby: () => Promise<void>,
+  ) {
+    super(workspaceFolder, outputChannel, context, manuallySelectRuby);
+
+    const configuredRubies = vscode.workspace
+      .getConfiguration("rubyLsp")
+      .get<string[] | undefined>("rubyVersionManager.chrubyRubies");
+
+    if (configuredRubies) {
+      this.rubyInstallationUris.push(...configuredRubies.map((path) => vscode.Uri.file(path)));
+    }
+  }
+
+  async activate(): Promise<ActivationResult> {
+    let versionInfo = await this.discoverRubyVersion();
+    let rubyUri: vscode.Uri | undefined;
+
+    // If the version informed is available, try to find the Ruby installation. Otherwise, try to fall back to an
+    // existing version
+    try {
+      if (versionInfo) {
+        rubyUri = await this.findRubyUri(versionInfo);
+      } else {
+        const fallback = await this.fallbackWithCancellation(
+          "No .ruby-version file found. Trying to fall back to latest installed Ruby in 10 seconds",
+          "You can create a .ruby-version file in a parent directory to configure a fallback",
+          this.findFallbackRuby.bind(this),
+          this.rubyVersionError.bind(this),
+        );
+
+        versionInfo = fallback.rubyVersion;
+        rubyUri = fallback.uri;
+      }
+    } catch (error: any) {
+      if (error instanceof RubyActivationCancellationError) {
+        // Try to re-activate if the user has configured a fallback during cancellation
+        return this.activate();
+      }
+
+      throw error;
+    }
+
+    // If we couldn't find a Ruby installation, that means there's a `.ruby-version` file, but that Ruby is not
+    // installed. In this case, we fallback to a closest installation of Ruby - preferably only varying in patch
+    try {
+      if (!rubyUri) {
+        const currentVersionInfo = { ...versionInfo };
+
+        const fallback = await this.fallbackWithCancellation(
+          `Couldn't find installation for ${versionInfo.version}. Trying to fall back to other Ruby in 10 seconds`,
+          "You can cancel this fallback and install the required Ruby",
+          async () => this.findClosestRubyInstallation(currentVersionInfo),
+          () => this.missingRubyError(currentVersionInfo.version),
+        );
+
+        versionInfo = fallback.rubyVersion;
+        rubyUri = fallback.uri;
+      }
+    } catch (error: any) {
+      if (error instanceof RubyActivationCancellationError) {
+        // Try to re-activate if the user has configured a fallback during cancellation
+        return this.activate();
+      }
+
+      throw error;
+    }
+
+    this.outputChannel.info(`Discovered Ruby installation at ${rubyUri.fsPath}`);
+
+    const { defaultGems, gemHome, yjit, version } = await this.runActivationScript(rubyUri, versionInfo);
+
+    this.outputChannel.info(`Activated Ruby environment: defaultGems=${defaultGems} gemHome=${gemHome} yjit=${yjit}`);
+
+    const rubyEnv = {
+      GEM_HOME: gemHome,
+      GEM_PATH: `${gemHome}${path.delimiter}${defaultGems}`,
+      PATH: `${path.join(gemHome, "bin")}${path.delimiter}${path.join(
+        defaultGems,
+        "bin",
+      )}${path.delimiter}${path.dirname(rubyUri.fsPath)}${path.delimiter}${this.getProcessPath()}`,
+    };
+
+    return {
+      env: { ...process.env, ...rubyEnv },
+      yjit,
+      version,
+      gemPath: [gemHome, defaultGems],
+    };
+  }
+
+  protected getProcessPath() {
+    return process.env.PATH;
+  }
+
+  // Returns the full URI to the Ruby executable
+  protected async findRubyUri(rubyVersion: RubyVersion): Promise<vscode.Uri | undefined> {
+    const possibleVersionNames = rubyVersion.engine
+      ? [`${rubyVersion.engine}-${rubyVersion.version}`, rubyVersion.version]
+      : [rubyVersion.version, `ruby-${rubyVersion.version}`];
+
+    for (const uri of this.rubyInstallationUris) {
+      let directories;
+
+      try {
+        directories = (await vscode.workspace.fs.readDirectory(uri)).sort((left, right) =>
+          right[0].localeCompare(left[0]),
+        );
+      } catch (_error: any) {
+        // If the directory doesn't exist, keep searching
+        this.outputChannel.debug(`Tried searching for Ruby installation in ${uri.fsPath} but it doesn't exist`);
+        continue;
+      }
+
+      for (const versionName of possibleVersionNames) {
+        const targetDirectory = directories.find(([name]) => name.startsWith(versionName));
+
+        if (targetDirectory) {
+          return vscode.Uri.joinPath(uri, targetDirectory[0], "bin", "ruby");
+        }
+      }
+    }
+
+    return undefined;
+  }
+
+  // Run the activation script using the Ruby installation we found so that we can discover gem paths
+  protected async runActivationScript(
+    rubyExecutableUri: vscode.Uri,
+    rubyVersion: RubyVersion,
+  ): Promise<{
+    defaultGems: string;
+    gemHome: string;
+    yjit: boolean;
+    version: string;
+  }> {
+    const activationUri = vscode.Uri.joinPath(this.context.extensionUri, "chruby_activation.rb");
+
+    const result = await this.runScript(
+      `${rubyExecutableUri.fsPath} -EUTF-8:UTF-8 '${activationUri.fsPath}' ${rubyVersion.version}`,
+    );
+
+    const [defaultGems, gemHome, yjit, version] = result.stderr.split(ACTIVATION_SEPARATOR);
+
+    return { defaultGems, gemHome, yjit: yjit === "true", version };
+  }
+
+  private async findClosestRubyInstallation(rubyVersion: RubyVersion): Promise<{
+    uri: vscode.Uri;
+    rubyVersion: RubyVersion;
+  }> {
+    const [major, minor, _patch] = rubyVersion.version.split(".");
+    const directories: { uri: vscode.Uri; rubyVersion: RubyVersion }[] = [];
+
+    for (const uri of this.rubyInstallationUris) {
+      try {
+        // Accumulate all directories that match the `engine-version` pattern and that start with the same requested
+        // major version. We do not try to approximate major versions
+        (await vscode.workspace.fs.readDirectory(uri)).forEach(([name]) => {
+          const match = /((?<engine>[A-Za-z]+)-)?(?<version>\d+\.\d+(\.\d+)?(-[A-Za-z0-9]+)?)/.exec(name);
+
+          if (match?.groups && match.groups.version.startsWith(major)) {
+            directories.push({
+              uri: vscode.Uri.joinPath(uri, name, "bin", "ruby"),
+              rubyVersion: {
+                engine: match.groups.engine,
+                version: match.groups.version,
+              },
+            });
+          }
+        });
+      } catch (_error: any) {
+        // If the directory doesn't exist, keep searching
+        this.outputChannel.debug(`Tried searching for Ruby installation in ${uri.fsPath} but it doesn't exist`);
+        continue;
+      }
+    }
+
+    // Sort the directories based on the difference between the minor version and the requested minor version. On
+    // conflicts, we use the patch version to break the tie. If there's no distance, we prefer the higher patch version
+    const closest = directories.sort((left, right) => {
+      const leftVersion = left.rubyVersion.version.split(".");
+      const rightVersion = right.rubyVersion.version.split(".");
+
+      const leftDiff = Math.abs(Number(leftVersion[1]) - Number(minor));
+      const rightDiff = Math.abs(Number(rightVersion[1]) - Number(minor));
+
+      // If the distance to minor version is the same, prefer higher patch number
+      if (leftDiff === rightDiff) {
+        return Number(rightVersion[2] || 0) - Number(leftVersion[2] || 0);
+      }
+
+      return leftDiff - rightDiff;
+    })[0];
+
+    if (closest) {
+      return closest;
+    }
+
+    throw new Error("Cannot find any Ruby installations");
+  }
+
+  // Returns the Ruby version information including version and engine. E.g.: ruby-3.3.0, truffleruby-21.3.0
+  private async discoverRubyVersion(): Promise<RubyVersion | undefined> {
+    let uri = this.bundleUri;
+    const root = path.parse(uri.fsPath).root;
+    let version: string;
+    let rubyVersionUri: vscode.Uri;
+
+    while (uri.fsPath !== root) {
+      try {
+        rubyVersionUri = vscode.Uri.joinPath(uri, ".ruby-version");
+        const content = await vscode.workspace.fs.readFile(rubyVersionUri);
+        version = content.toString().trim();
+      } catch (_error: any) {
+        // If the file doesn't exist, continue going up the directory tree
+        uri = vscode.Uri.file(path.dirname(uri.fsPath));
+        continue;
+      }
+
+      if (version === "") {
+        throw new Error(`Ruby version file ${rubyVersionUri.fsPath} is empty`);
+      }
+
+      const match = /((?<engine>[A-Za-z]+)-)?(?<version>\d+\.\d+(\.\d+)?(-[A-Za-z0-9]+)?)/.exec(version);
+
+      if (!match?.groups) {
+        throw new Error(
+          `Ruby version file ${rubyVersionUri.fsPath} contains invalid format. Expected (engine-)?version, got ${version}`,
+        );
+      }
+
+      this.outputChannel.info(`Discovered Ruby version ${version} from ${rubyVersionUri.fsPath}`);
+      return { engine: match.groups.engine, version: match.groups.version };
+    }
+
+    return undefined;
+  }
+
+  private async fallbackWithCancellation<T>(
+    title: string,
+    message: string,
+    fallbackFn: () => Promise<T>,
+    errorFn: () => Error,
+  ): Promise<T> {
+    let gemfileContents;
+
+    try {
+      gemfileContents = await vscode.workspace.fs.readFile(vscode.Uri.joinPath(this.workspaceFolder.uri, "Gemfile"));
+    } catch (_error: any) {
+      // The Gemfile doesn't exist
+    }
+
+    // If the Gemfile includes ruby version restrictions, then trying to fall back may lead to errors
+    if (gemfileContents && /^ruby(\s|\()("|')[\d.]+/.test(gemfileContents.toString())) {
+      throw errorFn();
+    }
+
+    const fallback = await vscode.window.withProgress(
+      {
+        title,
+        location: vscode.ProgressLocation.Notification,
+        cancellable: true,
+      },
+      async (progress, token) => {
+        progress.report({ message });
+
+        // If they don't cancel, we wait 10 seconds before falling back so that they are aware of what's happening
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 10000);
+
+          // If the user cancels the fallback, resolve immediately so that they don't have to wait 10 seconds
+          token.onCancellationRequested(() => {
+            resolve();
+          });
+        });
+
+        if (token.isCancellationRequested) {
+          await this.handleCancelledFallback(errorFn);
+
+          // We throw this error to be able to catch and re-run activation after the user has configured a fallback
+          throw new RubyActivationCancellationError();
+        }
+
+        return fallbackFn();
+      },
+    );
+
+    return fallback;
+  }
+
+  private async handleCancelledFallback(errorFn: () => Error) {
+    const answer = await vscode.window.showInformationMessage(
+      `The Ruby LSP requires a Ruby version to launch.
+      You can define a fallback for the system or for the Ruby LSP only`,
+      "System",
+      "Ruby LSP only",
+    );
+
+    if (answer === "System") {
+      await this.createParentRubyVersionFile(errorFn);
+    } else if (answer === "Ruby LSP only") {
+      await this.manuallySelectRuby();
+    }
+
+    throw errorFn();
+  }
+
+  private async createParentRubyVersionFile(errorFn: () => Error) {
+    const items: vscode.QuickPickItem[] = [];
+
+    for (const uri of this.rubyInstallationUris) {
+      let directories;
+
+      try {
+        directories = (await vscode.workspace.fs.readDirectory(uri)).sort((left, right) =>
+          right[0].localeCompare(left[0]),
+        );
+
+        directories.forEach((directory) => {
+          items.push({
+            label: directory[0],
+          });
+        });
+      } catch (_error: any) {
+        continue;
+      }
+    }
+
+    const answer = await vscode.window.showQuickPick(items, {
+      title: "Select a Ruby version to use as fallback",
+      ignoreFocusOut: true,
+    });
+
+    if (!answer) {
+      throw errorFn();
+    }
+
+    const targetDirectory = await vscode.window.showOpenDialog({
+      defaultUri: vscode.Uri.file(os.homedir()),
+      openLabel: "Add fallback in this directory",
+      canSelectFiles: false,
+      canSelectFolders: true,
+      canSelectMany: false,
+      title: "Select the directory to create the .ruby-version fallback in",
+    });
+
+    if (!targetDirectory) {
+      throw errorFn();
+    }
+
+    await vscode.workspace.fs.writeFile(
+      vscode.Uri.joinPath(targetDirectory[0], ".ruby-version"),
+      Buffer.from(answer.label),
+    );
+  }
+
+  private async findFallbackRuby(): Promise<{
+    uri: vscode.Uri;
+    rubyVersion: RubyVersion;
+  }> {
+    for (const uri of this.rubyInstallationUris) {
+      let directories;
+
+      try {
+        directories = (await vscode.workspace.fs.readDirectory(uri)).sort((left, right) =>
+          right[0].localeCompare(left[0]),
+        );
+
+        let groups;
+        let targetDirectory;
+
+        for (const directory of directories) {
+          const match = /((?<engine>[A-Za-z]+)-)?(?<version>\d+\.\d+(\.\d+)?(-[A-Za-z0-9]+)?)/.exec(directory[0]);
+
+          if (match?.groups) {
+            groups = match.groups;
+            targetDirectory = directory;
+            break;
+          }
+        }
+
+        if (targetDirectory && groups) {
+          return {
+            uri: vscode.Uri.joinPath(uri, targetDirectory[0], "bin", "ruby"),
+            rubyVersion: {
+              engine: groups.engine,
+              version: groups.version,
+            },
+          };
+        }
+      } catch (_error: any) {
+        // If the directory doesn't exist, keep searching
+        this.outputChannel.debug(`Tried searching for Ruby installation in ${uri.fsPath} but it doesn't exist`);
+        continue;
+      }
+    }
+
+    throw new Error("Cannot find any Ruby installations");
+  }
+
+  private missingRubyError(version: string) {
+    return new Error(`Cannot find Ruby installation for version ${version}`);
+  }
+
+  private rubyVersionError() {
+    return new Error(
+      `Cannot find .ruby-version file. Please specify the Ruby version in a
+           .ruby-version either in ${this.bundleUri.fsPath} or in a parent directory`,
+    );
+  }
+}

--- a/src/ruby/custom.ts
+++ b/src/ruby/custom.ts
@@ -1,0 +1,35 @@
+import * as vscode from "vscode";
+
+import { VersionManager, ActivationResult } from "./versionManager";
+
+// Custom
+//
+// Custom Ruby environment activation can be used for all cases where an existing version manager does not suffice.
+// Users are allowed to define a shell script that runs before calling ruby, giving them the chance to modify the PATH,
+// GEM_HOME and GEM_PATH as needed to find the correct Ruby runtime.
+export class Custom extends VersionManager {
+  async activate(): Promise<ActivationResult> {
+    const parsedResult = await this.runEnvActivationScript(`${this.customCommand()} && ruby`);
+
+    return {
+      env: { ...process.env, ...parsedResult.env },
+      yjit: parsedResult.yjit,
+      version: parsedResult.version,
+      gemPath: parsedResult.gemPath,
+    };
+  }
+
+  customCommand() {
+    const configuration = vscode.workspace.getConfiguration("rubyLsp");
+    const customCommand: string | undefined = configuration.get("customRubyCommand");
+
+    if (customCommand === undefined) {
+      throw new Error(
+        "The customRubyCommand configuration must be set when 'custom' is selected as the version manager. \
+        See the [README](https://shopify.github.io/ruby-lsp/version-managers.html) for instructions.",
+      );
+    }
+
+    return customCommand;
+  }
+}

--- a/src/ruby/mise.ts
+++ b/src/ruby/mise.ts
@@ -1,0 +1,65 @@
+import os from "os";
+
+import * as vscode from "vscode";
+
+import { VersionManager, ActivationResult } from "./versionManager";
+
+// Mise (mise en place) is a manager for dev tools, environment variables and tasks
+//
+// Learn more: https://github.com/jdx/mise
+export class Mise extends VersionManager {
+  async activate(): Promise<ActivationResult> {
+    const miseUri = await this.findMiseUri();
+
+    // The exec command in Mise is called `x`
+    const parsedResult = await this.runEnvActivationScript(`${miseUri.fsPath} x -- ruby`);
+
+    return {
+      env: { ...process.env, ...parsedResult.env },
+      yjit: parsedResult.yjit,
+      version: parsedResult.version,
+      gemPath: parsedResult.gemPath,
+    };
+  }
+
+  async findMiseUri(): Promise<vscode.Uri> {
+    const config = vscode.workspace.getConfiguration("rubyLsp");
+    const misePath = config.get<string | undefined>("rubyVersionManager.miseExecutablePath");
+
+    if (misePath) {
+      const configuredPath = vscode.Uri.file(misePath);
+
+      try {
+        await vscode.workspace.fs.stat(configuredPath);
+        return configuredPath;
+      } catch (_error: any) {
+        throw new Error(`Mise executable configured as ${configuredPath.fsPath}, but that file doesn't exist`);
+      }
+    }
+
+    // Possible mise installation paths
+    //
+    // 1. Installation from curl | sh (per mise.jdx.dev Getting Started)
+    // 2. Homebrew M series
+    // 3. Installation from `apt install mise`
+    const possiblePaths = [
+      vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".local", "bin", "mise"),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "opt", "homebrew", "bin", "mise"),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "bin", "mise"),
+    ];
+
+    for (const possiblePath of possiblePaths) {
+      try {
+        await vscode.workspace.fs.stat(possiblePath);
+        return possiblePath;
+      } catch (_error: any) {
+        // Continue looking
+      }
+    }
+
+    throw new Error(
+      `The Ruby LSP version manager is configured to be Mise, but could not find Mise installation. Searched in
+        ${possiblePaths.join(", ")}`,
+    );
+  }
+}

--- a/src/ruby/none.ts
+++ b/src/ruby/none.ts
@@ -1,0 +1,39 @@
+import * as vscode from "vscode";
+
+import { WorkspaceChannel } from "../workspaceChannel";
+
+import { VersionManager, ActivationResult } from "./versionManager";
+
+// None
+//
+// This "version manager" represents the case where no manager is used, but the environment still needs to be inserted
+// into the NodeJS process. For example, when you use Docker, install Ruby through Homebrew or use some other mechanism
+// to have Ruby available in your PATH automatically.
+//
+// If you don't have Ruby automatically available in your PATH and are not using a version manager, look into
+// configuring custom Ruby activation
+export class None extends VersionManager {
+  private readonly rubyPath: string;
+
+  constructor(
+    workspaceFolder: vscode.WorkspaceFolder,
+    outputChannel: WorkspaceChannel,
+    context: vscode.ExtensionContext,
+    manuallySelectRuby: () => Promise<void>,
+    rubyPath?: string,
+  ) {
+    super(workspaceFolder, outputChannel, context, manuallySelectRuby);
+    this.rubyPath = rubyPath ?? "ruby";
+  }
+
+  async activate(): Promise<ActivationResult> {
+    const parsedResult = await this.runEnvActivationScript(this.rubyPath);
+
+    return {
+      env: { ...process.env, ...parsedResult.env },
+      yjit: parsedResult.yjit,
+      version: parsedResult.version,
+      gemPath: parsedResult.gemPath,
+    };
+  }
+}

--- a/src/ruby/rbenv.ts
+++ b/src/ruby/rbenv.ts
@@ -1,0 +1,42 @@
+import * as vscode from "vscode";
+
+import { VersionManager, ActivationResult } from "./versionManager";
+
+// Seamlessly manage your app’s Ruby environment with rbenv.
+//
+// Learn more: https://github.com/rbenv/rbenv
+export class Rbenv extends VersionManager {
+  async activate(): Promise<ActivationResult> {
+    const rbenvExec = await this.findRbenv();
+
+    const parsedResult = await this.runEnvActivationScript(`${rbenvExec} exec ruby`);
+
+    return {
+      env: { ...process.env, ...parsedResult.env },
+      yjit: parsedResult.yjit,
+      version: parsedResult.version,
+      gemPath: parsedResult.gemPath,
+    };
+  }
+
+  private async findRbenv(): Promise<string> {
+    const config = vscode.workspace.getConfiguration("rubyLsp");
+    const configuredRbenvPath = config.get<string | undefined>("rubyVersionManager.rbenvExecutablePath");
+
+    if (configuredRbenvPath) {
+      return this.ensureRbenvExistsAt(configuredRbenvPath);
+    } else {
+      return this.findExec([vscode.Uri.file("/opt/homebrew/bin"), vscode.Uri.file("/usr/local/bin")], "rbenv");
+    }
+  }
+
+  private async ensureRbenvExistsAt(path: string): Promise<string> {
+    try {
+      await vscode.workspace.fs.stat(vscode.Uri.file(path));
+
+      return path;
+    } catch (_error: any) {
+      throw new Error(`The Ruby LSP version manager is configured to be rbenv, but ${path} does not exist`);
+    }
+  }
+}

--- a/src/ruby/rubyInstaller.ts
+++ b/src/ruby/rubyInstaller.ts
@@ -1,0 +1,65 @@
+import os from "os";
+
+import * as vscode from "vscode";
+
+import { Chruby } from "./chruby";
+
+interface RubyVersion {
+  engine?: string;
+  version: string;
+}
+
+// Most version managers do not support Windows. One popular way of installing Ruby on Windows is via RubyInstaller,
+// which places the rubies in directories like C:\Ruby32-x64 (i.e.: Ruby{major}{minor}-{arch}). To automatically switch
+// Ruby versions on Windows, we use the same mechanism as Chruby to discover the Ruby version based on `.ruby-version`
+// files and then try to search the directories commonly used by RubyInstaller.
+//
+// If we can't find it there, then we throw an error and rely on the user to manually select where Ruby is installed.
+export class RubyInstaller extends Chruby {
+  // Environment variables are case sensitive on Windows when we access them through NodeJS. We need to ensure that
+  // we're searching through common variations, so that we don't accidentally miss the path we should inherit
+  protected getProcessPath() {
+    return process.env.Path ?? process.env.PATH ?? process.env.path;
+  }
+
+  // Returns the full URI to the Ruby executable
+  protected async findRubyUri(rubyVersion: RubyVersion): Promise<vscode.Uri> {
+    const [major, minor, _patch] = rubyVersion.version.split(".").map(Number);
+
+    const possibleInstallationUris = [
+      vscode.Uri.joinPath(vscode.Uri.file("C:"), `Ruby${major}${minor}-${os.arch()}`),
+      vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), `Ruby${major}${minor}-${os.arch()}`),
+    ];
+
+    for (const installationUri of possibleInstallationUris) {
+      try {
+        await vscode.workspace.fs.stat(installationUri);
+        return vscode.Uri.joinPath(installationUri, "bin", "ruby");
+      } catch (_error: any) {
+        // Continue searching
+      }
+    }
+
+    throw new Error(
+      `Cannot find installation directory for Ruby version ${rubyVersion.version}.\
+         Searched in ${possibleInstallationUris.map((uri) => uri.fsPath).join(", ")}`,
+    );
+  }
+
+  protected async runActivationScript(
+    rubyExecutableUri: vscode.Uri,
+    rubyVersion: RubyVersion,
+  ): Promise<{
+    defaultGems: string;
+    gemHome: string;
+    yjit: boolean;
+    version: string;
+  }> {
+    const activationResult = await super.runActivationScript(rubyExecutableUri, rubyVersion);
+
+    activationResult.gemHome = activationResult.gemHome.replace(/\//g, "\\");
+    activationResult.defaultGems = activationResult.defaultGems.replace(/\//g, "\\");
+
+    return activationResult;
+  }
+}

--- a/src/ruby/rvm.ts
+++ b/src/ruby/rvm.ts
@@ -1,0 +1,50 @@
+import os from "os";
+
+import * as vscode from "vscode";
+
+import { ActivationResult, VersionManager } from "./versionManager";
+
+// Ruby enVironment Manager. It manages Ruby application environments and enables switching between them.
+// Learn more:
+// - https://github.com/rvm/rvm
+// - https://rvm.io
+export class Rvm extends VersionManager {
+  async activate(): Promise<ActivationResult> {
+    const installationPath = await this.findRvmInstallation();
+    const parsedResult = await this.runEnvActivationScript(installationPath.fsPath);
+
+    const activatedKeys = Object.entries(parsedResult.env)
+      .map(([key, value]) => `${key}=${value}`)
+      .join(" ");
+
+    this.outputChannel.info(`Activated Ruby environment: ${activatedKeys}`);
+
+    return {
+      env: { ...process.env, ...parsedResult.env },
+      yjit: parsedResult.yjit,
+      version: parsedResult.version,
+      gemPath: parsedResult.gemPath,
+    };
+  }
+
+  async findRvmInstallation(): Promise<vscode.Uri> {
+    const possiblePaths = [
+      vscode.Uri.joinPath(vscode.Uri.file(os.homedir()), ".rvm", "bin", "rvm-auto-ruby"),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "local", "rvm", "bin", "rvm-auto-ruby"),
+      vscode.Uri.joinPath(vscode.Uri.file("/"), "usr", "share", "rvm", "bin", "rvm-auto-ruby"),
+    ];
+
+    for (const uri of possiblePaths) {
+      try {
+        await vscode.workspace.fs.stat(uri);
+        return uri;
+      } catch (_error: any) {
+        // Continue to the next installation path
+      }
+    }
+
+    throw new Error(
+      `Cannot find RVM installation directory. Searched in ${possiblePaths.map((uri) => uri.fsPath).join(",")}`,
+    );
+  }
+}

--- a/src/ruby/shadowenv.ts
+++ b/src/ruby/shadowenv.ts
@@ -1,0 +1,72 @@
+import * as vscode from "vscode";
+
+import { asyncExec } from "../common";
+
+import { VersionManager, ActivationResult } from "./versionManager";
+
+// Shadowenv is a tool that allows managing environment variables upon entering a directory. It allows users to manage
+// which Ruby version should be used for each project, in addition to other customizations such as GEM_HOME.
+//
+// Learn more: https://github.com/Shopify/shadowenv
+export class UntrustedWorkspaceError extends Error {}
+
+export class Shadowenv extends VersionManager {
+  async activate(): Promise<ActivationResult> {
+    try {
+      await vscode.workspace.fs.stat(vscode.Uri.joinPath(this.bundleUri, ".shadowenv.d"));
+    } catch (_error: any) {
+      throw new Error(
+        "The Ruby LSP version manager is configured to be shadowenv, \
+        but no .shadowenv.d directory was found in the workspace",
+      );
+    }
+
+    const shadowenvExec = await this.findExec([vscode.Uri.file("/opt/homebrew/bin")], "shadowenv");
+
+    try {
+      const parsedResult = await this.runEnvActivationScript(`${shadowenvExec} exec -- ruby`);
+
+      // Do not let Shadowenv change the BUNDLE_GEMFILE. The server has to be able to control this in order to properly
+      // set up the environment
+      delete parsedResult.env.BUNDLE_GEMFILE;
+
+      return {
+        env: { ...process.env, ...parsedResult.env },
+        yjit: parsedResult.yjit,
+        version: parsedResult.version,
+        gemPath: parsedResult.gemPath,
+      };
+    } catch (error: any) {
+      const err = error as Error;
+      // If the workspace is untrusted, offer to trust it for the user
+      if (err.message.includes("untrusted shadowenv program")) {
+        const answer = await vscode.window.showErrorMessage(
+          `Tried to activate Shadowenv, but the workspace is untrusted.
+           Workspaces must be trusted to before allowing Shadowenv to load the environment for security reasons.`,
+          "Trust workspace",
+          "Shutdown Ruby LSP",
+        );
+
+        if (answer === "Trust workspace") {
+          await asyncExec("shadowenv trust", { cwd: this.bundleUri.fsPath });
+          return this.activate();
+        }
+
+        throw new UntrustedWorkspaceError("Cannot activate Ruby environment in an untrusted workspace");
+      }
+
+      try {
+        await asyncExec("shadowenv --version");
+      } catch (_error: any) {
+        throw new Error(
+          `Shadowenv executable not found. Ensure it is installed and available in the PATH.
+           This error may happen if your shell configuration is failing to be sourced from the editor or if
+           another extension is mutating the process PATH.`,
+        );
+      }
+
+      // If it failed for some other reason, present the error to the user
+      throw new Error(`Failed to activate Ruby environment with Shadowenv: ${error.message}`);
+    }
+  }
+}

--- a/src/ruby/versionManager.ts
+++ b/src/ruby/versionManager.ts
@@ -1,0 +1,111 @@
+import path from "path";
+import os from "os";
+
+import * as vscode from "vscode";
+
+import { WorkspaceChannel } from "../workspaceChannel";
+import { asyncExec } from "../common";
+
+export interface ActivationResult {
+  env: NodeJS.ProcessEnv;
+  yjit: boolean;
+  version: string;
+  gemPath: string[];
+}
+
+// Changes to either one of these values have to be synchronized with a corresponding update in `activation.rb`
+export const ACTIVATION_SEPARATOR = "RUBY_LSP_ACTIVATION_SEPARATOR";
+export const VALUE_SEPARATOR = "RUBY_LSP_VS";
+export const FIELD_SEPARATOR = "RUBY_LSP_FS";
+
+export abstract class VersionManager {
+  protected readonly outputChannel: WorkspaceChannel;
+  protected readonly workspaceFolder: vscode.WorkspaceFolder;
+  protected readonly bundleUri: vscode.Uri;
+  protected readonly manuallySelectRuby: () => Promise<void>;
+  protected readonly context: vscode.ExtensionContext;
+  private readonly customBundleGemfile?: string;
+
+  constructor(
+    workspaceFolder: vscode.WorkspaceFolder,
+    outputChannel: WorkspaceChannel,
+    context: vscode.ExtensionContext,
+    manuallySelectRuby: () => Promise<void>,
+  ) {
+    this.workspaceFolder = workspaceFolder;
+    this.outputChannel = outputChannel;
+    this.context = context;
+    this.manuallySelectRuby = manuallySelectRuby;
+    const customBundleGemfile = vscode.workspace.getConfiguration("rubyLsp").get<string>("bundleGemfile");
+
+    if (customBundleGemfile && customBundleGemfile.length > 0) {
+      this.customBundleGemfile = path.isAbsolute(customBundleGemfile)
+        ? customBundleGemfile
+        : path.resolve(path.join(this.workspaceFolder.uri.fsPath, customBundleGemfile));
+    }
+
+    this.bundleUri = this.customBundleGemfile
+      ? vscode.Uri.file(path.dirname(this.customBundleGemfile))
+      : workspaceFolder.uri;
+  }
+
+  // Activate the Ruby environment for the version manager, returning all of the necessary information to boot the
+  // language server
+  abstract activate(): Promise<ActivationResult>;
+
+  protected async runEnvActivationScript(activatedRuby: string): Promise<ActivationResult> {
+    const activationUri = vscode.Uri.joinPath(this.context.extensionUri, "activation.rb");
+
+    const result = await this.runScript(`${activatedRuby} -EUTF-8:UTF-8 '${activationUri.fsPath}'`);
+
+    const activationContent = new RegExp(`${ACTIVATION_SEPARATOR}([^]*)${ACTIVATION_SEPARATOR}`).exec(result.stderr);
+
+    const [version, gemPath, yjit, ...envEntries] = activationContent![1].split(FIELD_SEPARATOR);
+
+    return {
+      version,
+      gemPath: gemPath.split(","),
+      yjit: yjit === "true",
+      env: Object.fromEntries(envEntries.map((entry) => entry.split(VALUE_SEPARATOR))),
+    };
+  }
+
+  // Runs the given command in the directory for the Bundle, using the user's preferred shell and inheriting the current
+  // process environment
+  protected runScript(command: string) {
+    let shell: string | undefined;
+
+    // If the user has configured a default shell, we use that one since they are probably sourcing their version
+    // manager scripts in that shell's configuration files. On Windows, we never set the shell no matter what to ensure
+    // that activation runs on `cmd.exe` and not PowerShell, which avoids complex quoting and escaping issues.
+    if (vscode.env.shell.length > 0 && os.platform() !== "win32") {
+      shell = vscode.env.shell;
+    }
+
+    this.outputChannel.info(`Running command: \`${command}\` in ${this.bundleUri.fsPath} using shell: ${shell}`);
+
+    return asyncExec(command, {
+      cwd: this.bundleUri.fsPath,
+      shell,
+      env: process.env,
+      encoding: "utf-8",
+    });
+  }
+
+  // Tries to find `execName` within the given directories. Prefers the executables found in the given directories over
+  // finding the executable in the PATH
+  protected async findExec(directories: vscode.Uri[], execName: string) {
+    for (const uri of directories) {
+      try {
+        const fullUri = vscode.Uri.joinPath(uri, execName);
+        await vscode.workspace.fs.stat(fullUri);
+        this.outputChannel.info(`Found ${execName} executable at ${uri.fsPath}`);
+        return fullUri.fsPath;
+      } catch (_error: any) {
+        // continue searching
+      }
+    }
+
+    return execName;
+  }
+}

--- a/src/workspaceChannel.ts
+++ b/src/workspaceChannel.ts
@@ -1,0 +1,72 @@
+import * as vscode from "vscode";
+
+export class WorkspaceChannel implements vscode.LogOutputChannel {
+  public readonly onDidChangeLogLevel: vscode.Event<vscode.LogLevel>;
+  private readonly actualChannel: vscode.LogOutputChannel;
+  private readonly prefix: string;
+
+  constructor(workspaceName: string, actualChannel: vscode.LogOutputChannel) {
+    this.prefix = `(${workspaceName})`;
+    this.actualChannel = actualChannel;
+    this.onDidChangeLogLevel = this.actualChannel.onDidChangeLogLevel;
+  }
+
+  get name(): string {
+    return this.actualChannel.name;
+  }
+
+  get logLevel(): vscode.LogLevel {
+    return this.actualChannel.logLevel;
+  }
+
+  trace(message: string, ...args: any[]): void {
+    this.actualChannel.trace(`${this.prefix} ${message}`, ...args);
+  }
+
+  debug(message: string, ...args: any[]): void {
+    this.actualChannel.debug(`${this.prefix} ${message}`, ...args);
+  }
+
+  info(message: string, ...args: any[]): void {
+    this.actualChannel.info(`${this.prefix} ${message}`, ...args);
+  }
+
+  warn(message: string, ...args: any[]): void {
+    this.actualChannel.warn(`${this.prefix} ${message}`, ...args);
+  }
+
+  error(error: string | Error, ...args: any[]): void {
+    this.actualChannel.error(`${this.prefix} ${error}`, ...args);
+  }
+
+  append(value: string): void {
+    this.actualChannel.append(`${this.prefix} ${value}`);
+  }
+
+  appendLine(value: string): void {
+    this.actualChannel.appendLine(`${this.prefix} ${value}`);
+  }
+
+  replace(value: string): void {
+    this.actualChannel.replace(`${this.prefix} ${value}`);
+  }
+
+  clear(): void {
+    this.actualChannel.clear();
+  }
+
+  show(preserveFocus?: boolean): void;
+  show(column?: vscode.ViewColumn, preserveFocus?: boolean): void;
+
+  show(_column?: unknown, preserveFocus?: boolean): void {
+    this.actualChannel.show(preserveFocus);
+  }
+
+  hide(): void {
+    this.actualChannel.hide();
+  }
+
+  dispose(): void {
+    this.actualChannel.dispose();
+  }
+}


### PR DESCRIPTION
Part of https://github.com/Shopify/ruby-environments/pull/2

As a first step, I extracted code related to version managers from [ruby-lsp](https://github.com/Shopify/ruby-lsp/tree/main/vscode/src). Most code were extracted without any modifications.